### PR TITLE
avoid pessimistic busy render loop

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -853,7 +853,10 @@ impl Screen {
                 self.refresh_overlay();
             }
         }
-        Ok(Some(Action::Render))
+        match &self.pending_refresh {
+            Refresh::None => Ok(None),
+            _ => Ok(Some(Action::Render))
+        }
     }
 
     pub(crate) fn prompt(&mut self) -> &mut Option<Prompt> {


### PR DESCRIPTION
I noticed that running `sp < README.md` would spin 100% cpu for both `sp`
and my terminal emulator.  I ran this down to this bit of code,
which would force a full screen render every 100ms.

What seems to work for me is making this only return a Refresh
action if there is a pending refresh.