### PR TITLE
Implement non-fullscreen streaming rendering

### DIFF
--- a/examples/streams_example.rs
+++ b/examples/streams_example.rs
@@ -44,7 +44,9 @@ fn main() -> Result<()> {
     pager
         .add_output_stream(out_read, "output stream")?
         .add_error_stream(err_read, "error stream")?
-        .set_progress_stream(prog_read);
+        .set_progress_stream(prog_read)
+        .set_interface_mode(std::env::var("MODE").unwrap_or_default().as_ref());
+
     pager.run()?;
 
     println!("pager has exited");

--- a/examples/streams_example.sh
+++ b/examples/streams_example.sh
@@ -33,7 +33,7 @@ generate_progress() {
 }
 
 # Calling processes can provide input file descriptors using environment variables:
-generate_output | PAGER_TITLE=generate_output PAGER_ERROR_FD=55 PAGER_PROGRESS_FD=66 cargo run 55< <(generate_error) 66< <(generate_progress)
+generate_output | PAGER_TITLE=generate_output PAGER_ERROR_FD=55 PAGER_PROGRESS_FD=66 cargo run --bin sp 55< <(generate_error) 66< <(generate_progress)
 
 # Calling processes can provide input file descriptors using arguments:
 # generate_output | cargo run -- 55< <(generate_error) 66< <(generate_progress) --fd 0=generate_output --error-fd 55=ERR --progress-fd 66

--- a/src/bin/sp/app.rs
+++ b/src/bin/sp/app.rs
@@ -20,9 +20,17 @@ pub(crate) fn app() -> App<'static, 'static> {
                 .multiple(true),
         )
         .arg(
-            Arg::with_name("force")
-                .long("force")
-                .help("Start paging immediately, don't wait to see if input is short"),
+            Arg::with_name("delayed")
+                .long("delayed")
+                .short("D")
+                .value_name("SEC")
+                .help("Enter full screen after SEC seconds without waiting for content to fill one screen."),
+        )
+        .arg(
+            Arg::with_name("no_alternate")
+                .long("no-alternate")
+                .short("X")
+                .help("Disables using the alternate screen. Enables streaming output before full screen."),
         );
     if cfg!(unix) {
         app.arg(

--- a/src/bin/sp/main.rs
+++ b/src/bin/sp/main.rs
@@ -12,10 +12,11 @@ use std::fmt::Write;
 use std::os::unix::io::{FromRawFd, RawFd};
 #[cfg(unix)]
 use std::str::FromStr;
+use std::time::Duration;
 use termwiz::istty::IsTty;
 use vec_map::VecMap;
 
-use streampager::Pager;
+use streampager::{config::InterfaceMode, Pager};
 
 mod app;
 
@@ -52,6 +53,7 @@ enum FileSpec {
 fn open_files(args: ArgMatches) -> Result<(), Error> {
     let mut pager = Pager::new_using_system_terminal()?;
     let mut specs = VecMap::new();
+    pager.set_interface_mode(InterfaceMode::Delayed(Duration::from_secs(2)));
 
     // Collect file specifications from arguments.
     if let (Some(filenames), Some(indices)) = (args.values_of_os("FILE"), args.indices_of("FILE")) {
@@ -111,9 +113,9 @@ fn open_files(args: ArgMatches) -> Result<(), Error> {
             }
         }
 
-        if !args.is_present("force") {
-            pager.set_delay_fullscreen(true);
-        }
+        if args.is_present("force") {
+            pager.set_interface_mode(InterfaceMode::FullScreen);
+        };
     }
 
     #[cfg(unix)]

--- a/src/cat.rs
+++ b/src/cat.rs
@@ -1,0 +1,304 @@
+//! Support for `InterfaceMode::Cat` and other modes using `Cat`.
+
+use crate::config::InterfaceMode;
+use crate::event::{Event, EventStream};
+use crate::file::File;
+use crate::line::Line;
+use crate::progress::Progress;
+use anyhow::{ensure, Result};
+use std::time::{Duration, Instant};
+use termwiz::input::InputEvent;
+use termwiz::surface::change::Change;
+use termwiz::surface::Position;
+use termwiz::terminal::Terminal;
+use vec_map::VecMap;
+
+/// Return value of `cat`.
+pub(crate) enum Outcome {
+    /// Content is not completely rendered.
+    /// A hint to enter full-screen.
+    RenderIncomplete,
+
+    /// Content is not rendered at all.
+    /// A hint to enter full-screen.
+    RenderNothing,
+
+    /// Content is completely rendered.
+    RenderComplete,
+
+    /// The user pressed a key to exit.
+    Interrupted,
+}
+
+/// Streaming content to the terminal without entering full screen.
+///
+/// Similar to `tail -f`, but with dynamic progress support.
+/// Useful for rendering content before entering the full-screen mode.
+///
+/// Lines are rendered in this order:
+/// - Output (append-only)
+/// - Error (append-only)
+/// - Progress (mutable)
+///
+/// Return `Outcome::Interrupted` if `q` or `Ctrl+C` is pressed.
+/// Otherwise, return values and conditions are as follows:
+///
+/// | Interface  | Fits Screen | Streams Ended | Return           |
+/// |------------|-------------|---------------|------------------|
+/// | FullScreen | (any)       | (any)         | RenderNothing    |
+/// | Cat        | (any)       | no            | -                |
+/// | Cat        | (any)       | yes           | RenderComplete   |
+/// | Hybrid     | yes         | no            | -                |
+/// | Hybrid     | yes         | yes           | RenderComplete   |
+/// | Hybrid     | no          | (any)         | RenderIncomplete |
+/// | Delayed    | (any)       | no (time out) | RenderNothing    |
+/// | Delayed    | yes         | yes           | RenderComplete   |
+/// | Delayed    | no          | yes           | RenderNothing    |
+pub(crate) fn cat<T: Terminal>(
+    term: &mut T,
+    output_files: &[File],
+    error_files: &[File],
+    progress: Option<&Progress>,
+    events: &mut EventStream,
+    mode: InterfaceMode,
+) -> Result<Outcome> {
+    if mode == InterfaceMode::FullScreen {
+        return Ok(Outcome::RenderNothing);
+    }
+    let delayed_deadline = match mode {
+        InterfaceMode::Delayed(duration) => Some(Instant::now() + duration),
+        _ => None,
+    };
+
+    let mut last_read = VecMap::new(); // file index -> line number last read
+    let mut collect_unread = |files: &[File], max_lines: usize| -> Vec<Vec<u8>> {
+        let mut result = Vec::new();
+        for file in files.iter() {
+            let index = file.index();
+            let lines = file.lines();
+            let last = last_read.get(index).cloned().unwrap_or(0);
+            if lines >= last {
+                let lines = (last + max_lines).min(lines);
+                result.reserve(lines - last);
+                for i in last..lines {
+                    file.with_line(i, |l| result.push(l.to_vec()));
+                }
+                last_read.insert(index, lines);
+            }
+        }
+        result
+    };
+
+    let read_progress_lines = || -> Vec<Vec<u8>> {
+        let line_count = progress.map(|p| p.lines()).unwrap_or(0);
+        (0..line_count)
+            .filter_map(|i| progress.and_then(|p| p.with_line(i, |l| l.to_vec())))
+            .collect::<Vec<_>>()
+    };
+
+    let mut state = StreamingLines::default();
+    let delayed = delayed_deadline.is_some();
+    let has_one_screen_limit = match mode {
+        InterfaceMode::Cat => false,
+        _ => true,
+    };
+    let mut render = |term: &mut T, h: usize, w: usize| -> Result<Option<Outcome>> {
+        let append_output_lines = collect_unread(output_files, h + 2);
+        let append_error_lines = collect_unread(error_files, h + 2);
+        let progress_lines = read_progress_lines();
+        if delayed {
+            state.apply_changes(0, &append_output_lines, &append_error_lines, progress_lines);
+            if has_one_screen_limit && state.height() >= h {
+                return Ok(Some(Outcome::RenderNothing));
+            }
+        } else {
+            let changes = state.render_changes(
+                &append_output_lines,
+                &append_error_lines,
+                progress_lines,
+                w,
+            )?;
+            if has_one_screen_limit && state.height() >= h {
+                return Ok(Some(Outcome::RenderIncomplete));
+            }
+            term.render(&changes)?;
+        }
+        Ok(None)
+    };
+
+    let mut size = term.get_screen_size()?;
+    let mut loaded: VecMap<bool> = VecMap::new();
+    let mut remaining = output_files.len() + error_files.len();
+    while remaining > 0 {
+        match events.get(term, Some(Duration::from_millis(10)))? {
+            Some(Event::Loaded(i)) => {
+                if loaded.get(i) != Some(&true) {
+                    loaded.insert(i, true);
+                    remaining -= 1;
+                }
+            }
+            Some(Event::Input(InputEvent::Resized { .. })) => {
+                size = term.get_screen_size()?;
+            }
+            Some(Event::Input(InputEvent::Key(key))) => {
+                use termwiz::input::{KeyCode::Char, Modifiers};
+                match (key.modifiers, key.key) {
+                    (Modifiers::NONE, Char('q')) | (Modifiers::CTRL, Char('C')) => {
+                        return Ok(Outcome::Interrupted);
+                    }
+                    (Modifiers::NONE, Char('f')) | (Modifiers::NONE, Char(' ')) => {
+                        let outcome = if delayed {
+                            Outcome::RenderNothing
+                        } else {
+                            Outcome::RenderIncomplete
+                        };
+                        return Ok(outcome);
+                    }
+                    _ => (),
+                }
+            }
+            _ => (),
+        }
+        if let Some(deadline) = delayed_deadline {
+            if deadline <= Instant::now() {
+                return Ok(Outcome::RenderNothing);
+            }
+        }
+        if let Some(outcome) = render(term, size.rows, size.cols)? {
+            return Ok(outcome);
+        }
+    }
+
+    if delayed {
+        term.render(&state.render_all(size.cols)?)?;
+    }
+
+    Ok(Outcome::RenderComplete)
+}
+
+/// State for calculating how to incrementally render streaming changes.
+///
+/// +----------------------------+
+/// | past output (never redraw) |
+/// +----------------------------+
+/// | new output (just received) |
+/// +----------------------------+
+/// | error (always redraw)      |
+/// +----------------------------+
+/// | progress (always redraw)   |
+/// +----------------------------+
+#[derive(Default)]
+struct StreamingLines {
+    past_output_line_count: usize,
+    past_output_lines: Vec<Vec<u8>>,
+    error_lines: Vec<Vec<u8>>,
+    progress_lines: Vec<Vec<u8>>,
+}
+
+impl StreamingLines {
+    fn apply_changes(
+        &mut self,
+        past_output_line_count: usize,
+        append_output_lines: &[Vec<u8>],
+        append_error_lines: &[Vec<u8>],
+        replace_progress_lines: Vec<Vec<u8>>,
+    ) {
+        self.past_output_line_count += past_output_line_count;
+        self.past_output_lines
+            .extend_from_slice(append_output_lines);
+        self.error_lines.extend_from_slice(append_error_lines);
+        self.progress_lines = replace_progress_lines;
+    }
+
+    fn render_changes(
+        &mut self,
+        append_output_lines: &[Vec<u8>],
+        append_error_lines: &[Vec<u8>],
+        replace_progress_lines: Vec<Vec<u8>>,
+        terminal_width: usize,
+    ) -> Result<Vec<Change>> {
+        // Fast path: nothing changed?
+        if append_output_lines.is_empty()
+            && append_error_lines.is_empty()
+            && replace_progress_lines == self.progress_lines
+        {
+            return Ok(Vec::new());
+        }
+
+        let mut changes = Vec::with_capacity(
+            // *2: Every line needs at least 2 `Change`s: Text, and CursorPosition.
+            // +2: 2 Changes for erasing existing lines.
+            (append_output_lines.len() + append_error_lines.len() + replace_progress_lines.len())
+                * 2
+                + 2,
+        );
+
+        // Step 1: Erase progress, and error.
+        let erase_line_count = self.progress_lines.len() + self.error_lines.len();
+        if erase_line_count > 0 {
+            // XXX: This is a workaround to a bug in termwiz. It is only correct
+            // with the buggy termwiz! See https://github.com/wez/wezterm/pull/109.
+            // let dy = -(erase_line_count as isize);
+            let dy = (0xffffffff00000000u64 | (erase_line_count as u64)) as isize;
+            changes.push(Change::CursorPosition {
+                x: Position::NoChange,
+                y: Position::Relative(dy),
+            });
+            changes.push(Change::ClearToEndOfScreen(Default::default()));
+        }
+
+        // Step 2: Render new output + error + progress
+        for line in append_output_lines
+            .iter()
+            .chain(self.error_lines.iter())
+            .chain(append_error_lines.iter())
+            .chain(replace_progress_lines.iter())
+        {
+            let line = Line::new(0, line);
+            line.render(&mut changes, 0, terminal_width, None)?;
+            changes.push(Change::CursorPosition {
+                x: Position::Absolute(0),
+                y: Position::Relative(1),
+            });
+        }
+
+        // Step 3: Update internal state.
+        self.apply_changes(
+            append_output_lines.len(),
+            &[],
+            append_error_lines,
+            replace_progress_lines,
+        );
+
+        Ok(changes)
+    }
+
+    fn render_all(&self, terminal_width: usize) -> Result<Vec<Change>> {
+        ensure!(
+            self.past_output_line_count == 0,
+            "bug: render_all() does not support past_output_line_count > 0"
+        );
+        let mut changes = Vec::with_capacity(self.height() * 2);
+        for line in self
+            .past_output_lines
+            .iter()
+            .chain(self.error_lines.iter())
+            .chain(self.progress_lines.iter())
+        {
+            let line = Line::new(0, line);
+            line.render(&mut changes, 0, terminal_width, None)?;
+            changes.push(Change::CursorPosition {
+                x: Position::Absolute(0),
+                y: Position::Relative(1),
+            });
+        }
+        Ok(changes)
+    }
+
+    fn height(&self) -> usize {
+        self.past_output_line_count
+            + self.past_output_lines.len()
+            + self.error_lines.len()
+            + self.progress_lines.len()
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,103 @@
+//! Configuration that affects Pager behaviors.
+
+use std::time::Duration;
+
+/// Specify what interface to use.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum InterfaceMode {
+    /// The full screen terminal interface.
+    ///
+    /// Support text search and other operations.
+    ///
+    /// Use the alternate screen. The pager UI will disappear completely at
+    /// exit (except for terminals without alternate screen support).
+    ///
+    /// Similar to external command `less` without flags. This is the default.
+    FullScreen,
+
+    /// The minimal interface. Output goes to the terminal directly.
+    ///
+    /// Does not support text search or other fancy operations.
+    ///
+    /// Does not use the alternate screen. Content will be kept in the terminal
+    /// at exit.
+    ///
+    /// Error messages and progress messages are printed after
+    /// outputs.
+    ///
+    /// Similar to shell command `cat` without buffering.
+    Cat,
+
+    /// Hybrid: `Cat` first, `FullScreen` next.
+    ///
+    /// `Cat` is used initially. When content exceeds one screen, switch to the
+    /// `FullScreen` interface.
+    ///
+    /// Unlike `FullScreen` or `Delayed`, skip initializing the alternate
+    /// screen. This is because the initial `Cat` might have "polluted"
+    /// the terminal.
+    ///
+    /// Similar to external command `less -F -X`.
+    Hybrid,
+
+    /// Wait to decide.
+    ///
+    /// If output completes in the delayed time, and is within one screen, print
+    /// the output and exit. Otherwise, enter the `FullScreen` interface.
+    ///
+    /// Unlike `Hybrid`, output is buffered in memory. So the terminal is not
+    /// "polluted" and the alternate screen is used for the `FullScreen`
+    /// interface.
+    ///
+    /// If duration is set to infinite, similar to external command `less -F`.
+    /// If duration is set to 0, similar to `FullScreen`.
+    Delayed(Duration),
+}
+
+impl Default for InterfaceMode {
+    fn default() -> Self {
+        Self::FullScreen
+    }
+}
+
+impl From<&str> for InterfaceMode {
+    fn from(value: &str) -> InterfaceMode {
+        match value.to_lowercase().as_ref() {
+            "full" | "fullscreen" | "" => InterfaceMode::FullScreen,
+            "cat" => InterfaceMode::Cat,
+            "hybrid" => InterfaceMode::Hybrid,
+            s if s.starts_with("delayed") => {
+                let duration = s.rsplit(":").nth(0).unwrap_or("inf");
+                let duration = if duration.ends_with("ms") {
+                    // ex. delayed:100ms
+                    Duration::from_millis(duration.trim_end_matches("ms").parse().unwrap_or(0))
+                } else {
+                    // ex. delayed:1s, delayed:1, delayed
+                    Duration::from_secs(duration.trim_end_matches("s").parse().unwrap_or(1 << 30))
+                };
+                InterfaceMode::Delayed(duration)
+            }
+            _ => InterfaceMode::default(),
+        }
+    }
+}
+
+/// A group of configurations.
+#[derive(Clone, PartialEq, Eq, Default)]
+pub struct Config {
+    /// Specify when to use fullscreen.
+    pub interface_mode: InterfaceMode,
+}
+
+impl Config {
+    /// Construct [`Config`] from environment variables.
+    pub fn from_env() -> Self {
+        use std::env::var;
+        Self {
+            interface_mode: var("SP_INTERFACE_MODE")
+                .ok()
+                .map(|s| InterfaceMode::from(s.as_ref()))
+                .unwrap_or(Default::default()),
+        }
+    }
+}

--- a/src/display.rs
+++ b/src/display.rs
@@ -10,7 +10,9 @@ use termwiz::surface::{CursorShape, Position};
 use termwiz::terminal::Terminal;
 use vec_map::VecMap;
 
+use crate::cat;
 use crate::command;
+use crate::config::Config;
 use crate::event::{Event, EventStream, UniqueInstance};
 use crate::file::File;
 use crate::progress::Progress;
@@ -146,13 +148,37 @@ impl Screens {
 
 /// Start displaying files.
 pub(crate) fn start(
-    term: impl Terminal,
+    mut term: impl Terminal,
     term_caps: TermCapabilities,
-    events: EventStream,
+    mut events: EventStream,
     files: Vec<File>,
     error_files: VecMap<File>,
     progress: Option<Progress>,
+    config: Config,
 ) -> Result<(), Error> {
+    let outcome = {
+        // Only take the first output and error. This emulates the behavior that
+        // the main pager can only display one stream at a time.
+        let output_files = &files[0..1.min(files.len())];
+        let error_files = match error_files.iter().nth(0) {
+            None => Vec::new(),
+            Some((_i, file)) => vec![file.clone()],
+        };
+        cat::cat(
+            &mut term,
+            output_files,
+            &error_files[..],
+            progress.as_ref(),
+            &mut events,
+            config.interface_mode,
+        )?
+    };
+    match outcome {
+        cat::Outcome::RenderComplete | cat::Outcome::Interrupted => return Ok(()),
+        cat::Outcome::RenderIncomplete => (),
+        cat::Outcome::RenderNothing => term.enter_alternate_screen()?,
+    }
+
     let mut term = guard(term, |mut term| {
         // Clean up when exiting.  Most of this should be achieved by exiting
         // the alternate screen, but just in case it isn't, move to the
@@ -178,7 +204,6 @@ pub(crate) fn start(
     let event_sender = events.sender();
     let render_unique = UniqueInstance::new();
     let refresh_unique = UniqueInstance::new();
-    term.enter_alternate_screen()?;
     {
         let screen = screens.current();
         let size = term.get_screen_size()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,15 +7,14 @@ pub use anyhow::Result;
 use anyhow::{anyhow, bail};
 use std::ffi::OsStr;
 use std::io::Read;
-use std::time;
 use termwiz::caps::{Capabilities, ProbeHintsBuilder};
-use termwiz::input::InputEvent;
-use termwiz::surface::{change::Change, Position};
 use termwiz::terminal::{SystemTerminal, Terminal};
 use vec_map::VecMap;
 
 mod buffer;
+mod cat;
 mod command;
+pub mod config;
 mod display;
 mod event;
 mod file;
@@ -28,9 +27,9 @@ mod refresh;
 mod screen;
 mod search;
 
-use event::{Event, EventStream};
+use config::{Config, InterfaceMode};
+use event::EventStream;
 use file::File;
-use line::Line;
 use progress::Progress;
 
 /// The main pager state.
@@ -53,9 +52,8 @@ pub struct Pager {
     /// Progress indicators to display.
     progress: Option<Progress>,
 
-    /// Whether `sp` should wait to see if enough input is generated to fill
-    /// the screen.
-    delay_fullscreen: bool,
+    /// Configuration.
+    config: Config,
 }
 
 /// Determine terminal capabilities and open the terminal.
@@ -84,7 +82,7 @@ impl Pager {
         let files = Vec::new();
         let error_files = VecMap::new();
         let progress = None;
-        let delay_fullscreen = true;
+        let config = Config::from_env();
 
         Ok(Self {
             term,
@@ -93,7 +91,7 @@ impl Pager {
             files,
             error_files,
             progress,
-            delay_fullscreen,
+            config,
         })
     }
 
@@ -162,112 +160,22 @@ impl Pager {
         self
     }
 
-    /// Set whether fullscreen should be delayed.
-    pub fn set_delay_fullscreen(&mut self, value: bool) -> &mut Self {
-        self.delay_fullscreen = value;
+    /// Set when to use full screen mode. See [`InterfaceMode`] for details.
+    pub fn set_interface_mode(&mut self, value: impl Into<InterfaceMode>) -> &mut Self {
+        self.config.interface_mode = value.into();
         self
     }
 
     /// Run Stream Pager.
     pub fn run(self) -> Result<()> {
-        run(self)
+        display::start(
+            self.term,
+            self.caps,
+            self.events,
+            self.files,
+            self.error_files,
+            self.progress,
+            self.config,
+        )
     }
-}
-
-/// Run Stream Pager.
-fn run(mut spec: Pager) -> Result<()> {
-    // If we are delaying fullsceeen (e.g. because wre are paging stdin without --force)
-    // then wait for up to two seconds to see if this is a small amount of
-    // output that we don't need to page.
-    if spec.delay_fullscreen {
-        let load_delay = time::Duration::from_millis(2000);
-        if wait_for_screenful(&spec.files, &mut spec.term, &mut spec.events, load_delay)? {
-            // The input streams have all completed and they fit on a single
-            // screen, just write them out and stop.
-            let mut changes = Vec::new();
-            for file in spec.files.iter() {
-                for i in 0..file.lines() {
-                    if let Some(line) = file.with_line(i, |line| Line::new(i, line)) {
-                        line.render_full(&mut changes)?;
-                        changes.push(Change::CursorPosition {
-                            x: Position::Absolute(0),
-                            y: Position::Relative(1),
-                        });
-                    }
-                }
-                spec.term.render(changes.as_slice())?;
-                return Ok(());
-            }
-        }
-    }
-
-    display::start(
-        spec.term,
-        spec.caps,
-        spec.events,
-        spec.files,
-        spec.error_files,
-        spec.progress,
-    )
-}
-
-/// Poll the event stream, waiting until either the file has finished loading,
-/// the file definitely doesn't fit on the screen, or the load delay has passed.
-///
-/// If the file has finished loading and the file fits on the screen, returns
-/// true.  Otherwise, returns false.
-fn wait_for_screenful<T: Terminal>(
-    files: &[File],
-    term: &mut T,
-    events: &mut EventStream,
-    load_delay: time::Duration,
-) -> Result<bool> {
-    let load_start = time::Instant::now();
-    let mut size = term.get_screen_size()?;
-    let mut loaded: Vec<bool> = files.iter().map(|_| false).collect();
-    while load_start.elapsed() < load_delay {
-        match events.get(term, Some(time::Duration::from_millis(50)))? {
-            Some(Event::Loaded(i)) => {
-                loaded[i] = true;
-                if loaded.iter().all(|l| *l) {
-                    if files_fit(files, size.cols, size.rows) {
-                        return Ok(true);
-                    }
-                    break;
-                }
-            }
-            Some(Event::Input(InputEvent::Resized { .. })) => {
-                size = term.get_screen_size()?;
-            }
-            Some(Event::Input(InputEvent::Key(_))) => break,
-            _ => {}
-        }
-        if !files_fit(files, size.cols, size.rows) {
-            break;
-        }
-    }
-    Ok(false)
-}
-
-/// Returns true if the given files fit on a screen of dimensions `w` x `h`.
-fn files_fit(files: &[File], w: usize, h: usize) -> bool {
-    let mut wrapped_lines = 0;
-    for file in files.iter() {
-        let lines = file.lines();
-        if wrapped_lines + lines > h {
-            return false;
-        }
-        for i in 0..lines {
-            wrapped_lines += file
-                .with_line(i, |line| {
-                    let line = Line::new(i, line);
-                    line.height(w)
-                })
-                .unwrap_or(0);
-            if wrapped_lines > h {
-                return false;
-            }
-        }
-    }
-    true
 }


### PR DESCRIPTION
This matches `less -F -X` behavior before entering the full screen - lines are printed as the pager recieves them.

Demo: https://asciinema.org/a/KZbc9K1elnz9alqxbCq6k1XLK

I had a hard time naming the feature. Better names are welcome.