### PR TITLE
Bounded read ahead for streams

### DIFF
--- a/examples/streams_example.rs
+++ b/examples/streams_example.rs
@@ -13,8 +13,10 @@ fn main() -> Result<()> {
 
     spawn(move || {
         for i in 1..=100 {
-            let _ = out_write.write_all(format!("this is line {}\n", i).as_bytes());
-            sleep(Duration::from_millis(450));
+            let _ = out_write.write_all(b"this is line");
+            sleep(Duration::from_millis(225));
+            let _ = out_write.write_all(format!(" {}\n", i).as_bytes());
+            sleep(Duration::from_millis(225));
         }
         let _ = out_write.write_all(b"this is the end of output stream\n");
     });

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,9 @@ pub struct Config {
 
     /// Specify whether scrolling down can past end of file.
     pub scroll_past_eof: bool,
+
+    /// Specify how many lines to read ahead.
+    pub read_ahead_lines: usize,
 }
 
 impl Config {
@@ -105,6 +108,10 @@ impl Config {
                 .ok()
                 .and_then(|s| parse_bool(&s))
                 .unwrap_or(true),
+            read_ahead_lines: var("SP_READ_AHEAD_LINES")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(crate::file::DEFAULT_NEEDED_LINES),
         }
     }
 }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -77,6 +77,7 @@ pub(crate) fn direct<T: Terminal>(
             let index = file.index();
             let mut lines = file.lines();
             let last = last_read.get(index).cloned().unwrap_or(0);
+            file.set_needed_lines(last + max_lines);
             // Ignore the incomplete last line if the file is loading.
             if lines > 0
                 && !file.loaded()

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -75,8 +75,17 @@ pub(crate) fn direct<T: Terminal>(
         let mut result = Vec::new();
         for file in files.iter() {
             let index = file.index();
-            let lines = file.lines();
+            let mut lines = file.lines();
             let last = last_read.get(index).cloned().unwrap_or(0);
+            // Ignore the incomplete last line if the file is loading.
+            if lines > 0
+                && !file.loaded()
+                && file
+                    .with_line(lines - 1, |l| !l.ends_with(b"\n"))
+                    .unwrap_or(true)
+            {
+                lines -= 1;
+            }
             if lines >= last {
                 let lines = (last + max_lines).min(lines);
                 result.reserve(lines - last);

--- a/src/display.rs
+++ b/src/display.rs
@@ -215,6 +215,7 @@ pub(crate) fn start(
         let screen = screens.current();
         let size = term.get_screen_size()?;
         screen.resize(size.cols, size.rows);
+        screen.maybe_load_more();
         term.render(&screen.render(&caps)?)?;
     }
     loop {
@@ -229,6 +230,8 @@ pub(crate) fn start(
         // Dispatch the event and receive an action to take.
         let mut action = {
             let screen = screens.current();
+            screen.maybe_load_more();
+
             match event {
                 None => screen.dispatch_animation()?,
                 Some(Event::Render) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,12 @@ impl Pager {
         self
     }
 
+    /// Set how many lines to read ahead.
+    pub fn set_read_ahead_lines(&mut self, lines: usize) -> &mut Self {
+        self.config.read_ahead_lines = lines;
+        self
+    }
+
     /// Run Stream Pager.
     pub fn run(self) -> Result<()> {
         display::start(


### PR DESCRIPTION
Pause loading input streams if they produce too much data. For commands like `hg log`, the blocking behavior can pause their calculation, which can be desirable.

Fixes #7.