### PR TITLE
Improve early exit handling

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -155,6 +155,10 @@ impl FileData {
                             return Ok(());
                         }
                         Ok(len) => {
+                            // If the pager has exited, ping() will fail and
+                            // this thread will drop "input". If "input" is a
+                            // pipe, the other end will notice EOF.
+                            event_sender.ping()?;
                             // Some data has been read.  Parse its newlines.
                             let line_count = {
                                 let mut newlines = meta.newlines.write().unwrap();


### PR DESCRIPTION
When the pager exits early, it's expected to:
- Close streams that are being loaded. In a pipe's case the other end will get an error writing more data to them.
- Internal threads should not panic and exit soon.

This PR addresses panic and "close stream" issues. I didn't looked into the watcher thread since the main usecase is the stream-typed Files.