### PR TITLE
`b` scrolls back a page

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -695,7 +695,9 @@ impl Screen {
 
             // 1 screen
             (NONE, PageDown) | (NONE, Char(' ')) | (CTRL, Char('F')) => self.scroll_down_screen(1),
-            (NONE, PageUp) | (NONE, Backspace) | (CTRL, Char('B')) => self.scroll_down_screen(-1),
+            (NONE, PageUp) | (NONE, Backspace) | (NONE, Char('b')) | (CTRL, Char('B')) => {
+                self.scroll_down_screen(-1)
+            }
 
             (NONE, End) | (NONE, Char('G')) => self.following_end = true,
             (NONE, Home) | (NONE, Char('g')) => self.scroll_up(self.position.top),


### PR DESCRIPTION
The readme says that this is supposed to happen, but it wasn't hooked
up.  I can see that CTRL-B was attached to this.

I've just added plain old `b` just like `less` here.