### PR TITLE
termwiz master replaced Position::NoChange with Position::Relative(0)

### DIFF
--- a/src/direct.rs
+++ b/src/direct.rs
@@ -248,7 +248,7 @@ impl StreamingLines {
         if erase_line_count > 0 {
             let dy = -(erase_line_count as isize);
             changes.push(Change::CursorPosition {
-                x: Position::NoChange,
+                x: Position::Relative(0),
                 y: Position::Relative(dy),
             });
             changes.push(Change::ClearToEndOfScreen(Default::default()));

--- a/src/line.rs
+++ b/src/line.rs
@@ -548,7 +548,7 @@ impl Line {
                 changes.push(Change::Text("\x08".into()));
                 changes.push(Change::CursorPosition {
                     x: Position::Relative(1),
-                    y: Position::NoChange,
+                    y: Position::Relative(0),
                 });
                 changes.push(Change::AllAttributes(
                     CellAttributes::default()


### PR DESCRIPTION
They are equivalent in behavior and the ambiguous representation was
a bit of headache when it came to computing and understanding exhaustive
matches in the renderer.

Prep for this change here in streampager.