### PR TITLE
Do not fail the build if a2x fails

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -55,8 +55,7 @@ fn generate_man_page(out_dir: impl AsRef<Path>) -> Result<(), io::Error> {
         .spawn()?
         .wait()?;
     if !result.success() {
-        let msg = format!("'a2x' failed with exit code {:?}", result.code());
-        return Err(io::Error::new(io::ErrorKind::Other, msg));
+        eprintln!("'a2x' failed with exit code {:?}", result.code());
     }
     Ok(())
 }


### PR DESCRIPTION
Failing to generate man pages shouldn't cause the build to fail. Just
print an error message in this case.