### PR TITLE
Add "d" and "u" less bindings for down and up

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -690,8 +690,8 @@ impl Screen {
             (SHIFT, DownArrow) | (NONE, ApplicationDownArrow) => self.scroll_down_screen(4),
 
             // 1/2 screen
-            (CTRL, Char('D')) => self.scroll_down_screen(2),
-            (CTRL, Char('U')) => self.scroll_down_screen(-2),
+            (CTRL, Char('D')) | (NONE, Char('d')) => self.scroll_down_screen(2),
+            (CTRL, Char('U')) | (NONE, Char('u')) => self.scroll_down_screen(-2),
 
             // 1 screen
             (NONE, PageDown) | (NONE, Char(' ')) | (CTRL, Char('F')) => self.scroll_down_screen(1),


### PR DESCRIPTION
In less: http://man7.org/linux/man-pages/man1/less.1.html

```
d or ^D
      Scroll forward N lines, default one half of the screen size.
      If N is specified, it becomes the new default for subsequent d
      and u commands.

u or ^U
      Scroll backward N lines, default one half of the screen size.
      If N is specified, it becomes the new default for subsequent d
      and u commands.
```

It looks like we have the CTRL variants, but not the plainer ones. This
adds them.

Shall we add those here too? :)