### PR TITLE
Allow configuring whether the ruler should be rendered

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,9 @@ pub struct Config {
 
     /// Specify default wrapping move.
     pub wrapping_mode: WrappingMode,
+
+    /// Whether to render the ruler.
+    pub render_ruler: bool,
 }
 
 impl Config {
@@ -143,6 +146,10 @@ impl Config {
                 .and_then(|s| s.parse::<usize>().ok())
                 .unwrap_or(crate::file::DEFAULT_NEEDED_LINES),
             wrapping_mode: WrappingMode::Unwrapped,
+            render_ruler: var("SP_RENDER_RULER")
+                .ok()
+                .and_then(|s| parse_bool(&s))
+                .unwrap_or(true),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,12 @@ impl Pager {
         self
     }
 
+    /// Set whether the ruler should be drawn.
+    pub fn set_render_ruler(&mut self, render_ruler: bool) -> &mut Self {
+        self.config.render_ruler = render_ruler;
+        self
+    }
+
     /// Run Stream Pager.
     pub fn run(self) -> Result<()> {
         display::start(


### PR DESCRIPTION
The ruler is useful when using the pager to look at a file or long
output, but can be disruptive when working with short lived commands.

Add a config option to no longer render the ruler.

I tested this by running:

```
SP_RENDER_RULER=false cargo run --bin sp -- CONTRIBUTING.md
```

and verifying that the ruler isn't rendered and common functionality such as moving around still works. I also ran `cargo test`.