### PR TITLE
Refactor to use own Error type in the library api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,9 +702,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.56",
 ]
 
 [[package]]
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -804,7 +804,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
 ]
 
 [[package]]
@@ -974,9 +974,9 @@ version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.56",
 ]
 
 [[package]]
@@ -1067,6 +1067,7 @@ dependencies = [
  "tempfile",
  "terminfo",
  "termwiz",
+ "thiserror",
  "toml",
  "unicode-segmentation",
  "unicode-width",
@@ -1092,11 +1093,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
@@ -1192,22 +1193,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.14"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.14"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.56",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ toml = "0.5.6"
 unicode-segmentation = "1.2.1"
 unicode-width = "0.1.5"
 vec_map = "0.8.1"
+thiserror = "1.0.23"
 
 [build-dependencies]
 clap = "2.32.0"

--- a/src/bin/sp/main.rs
+++ b/src/bin/sp/main.rs
@@ -179,7 +179,8 @@ fn open_files(args: ArgMatches) -> Result<(), Error> {
             }
         }
     }
-    pager.run()
+    pager.run()?;
+    Ok(())
 }
 
 #[cfg(unix)]

--- a/src/bin/spp/main.rs
+++ b/src/bin/spp/main.rs
@@ -41,5 +41,6 @@ fn start_command() -> Result<(), Error> {
         .collect::<Vec<_>>()
         .join(" ");
     pager.add_subprocess(&args[1], &args[2..], &title)?;
-    pager.run()
+    pager.run()?;
+    Ok(())
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -5,30 +5,40 @@ use indexmap::IndexMap;
 use termwiz::input::{KeyCode, Modifiers};
 use thiserror::Error;
 
+/// Errors specific to bindings.
 #[derive(Debug, Error)]
 pub enum BindingError {
+    /// Error when a binding is invalid.
     #[error("invalid: {0}")]
     Invalid(String),
 
+    /// Binding is missing a parameter.
     #[error("{0} missing parameter {1}")]
     MissingParameter(String, usize),
 
+    /// Integer parsing error.
     #[error("invalid integer: {0}")]
     InvalidInt(#[from] std::num::ParseIntError),
 
-    #[error("for {param} parameter {index}: {error}")]
+    /// Wrapped error within the context of a binding parameter.
+    #[error("for {binding} parameter {index}: {error}")]
     ForParameter {
+        /// Wrapped error.
         #[source] error: Box<BindingError>,
-        param: String,
+
+        /// Binding.
+        binding: String,
+
+        /// Parameter index.
         index: usize,
     },
 }
 
 impl BindingError {
-    fn for_parameter(self, param: String, index: usize) -> Self {
+    fn for_parameter(self, binding: String, index: usize) -> Self {
         Self::ForParameter {
             error: Box::new(self),
-            param,
+            binding,
             index,
         }
     }

--- a/src/buffer_cache.rs
+++ b/src/buffer_cache.rs
@@ -1,5 +1,4 @@
 //! Buffer Cache.
-use anyhow::Error;
 use lru::LruCache;
 use std::borrow::Cow;
 use std::fs::File as StdFile;
@@ -7,6 +6,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use crate::buffer::Buffer;
+use crate::error::Error;
 
 pub(crate) struct BufferCache {
     path: PathBuf,
@@ -151,7 +151,6 @@ fn fill_buffer(
 #[cfg(test)]
 mod test {
     use super::*;
-    use anyhow::Error;
     use std::io::Write;
     use tempfile::NamedTempFile;
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,10 +1,9 @@
 //! Commands
 //!
 //! Commands the user can invoke.
-use anyhow::Error;
-
 use crate::display::Action;
 use crate::event::EventSender;
+use crate::error::Error;
 use crate::prompt::Prompt;
 use crate::screen::Screen;
 use crate::search::{MatchMotion, Search, SearchKind};

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,10 +3,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
 use serde::Deserialize;
 
 use crate::bindings::Keymap;
+use crate::error::Result;
 
 /// Specify what interface to use.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,54 +9,74 @@ use thiserror::Error;
 /// Convenient return type for functions.
 pub type Result<T> = StdResult<T, Error>;
 
-/// Main error type
+/// Main error type.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// Comes from [Termwiz](https://crates.io/crates/termwiz).
     #[error("termwiz: {0}")]
-    Termwiz(anyhow::Error),
+    Termwiz(#[source] anyhow::Error),
 
+    /// Comes from [Regex](https://github.com/rust-lang/regex).
     #[error("regex: {0}")]
     Regex(#[from] regex::Error),
 
+    /// Generic I/O error.
     #[error("i/o: {0}")]
     Io(#[from] std::io::Error),
 
+    /// Returned when persisting a temporary file fails.
     #[error("temporary file persistence: {0}")]
     TempfilePersist(#[from] tempfile::PersistError),
 
+    /// Keymap-related error.
     #[error("keymap: {0}")]
     Keymap(#[from] crate::keymaps::error::KeymapError),
 
+    /// Binding-related error.
     #[error("binding: {0}")]
     Binding(#[from] crate::bindings::BindingError),
 
+    /// Generic formatting error.
     #[error("formatting: {0}")]
     Fmt(#[from] std::fmt::Error),
 
+    /// Receive error on a channel.
     #[error("channel: {0}")]
     ChannelRecv(#[from] RecvError),
 
+    /// (Try)Receive error on a channel.
     #[error("channel: {0}")]
     ChannelTryRecv(#[from] TryRecvError),
 
+    /// Send error on a FileEvent channel.
     #[error("channel: {0}")]
     ChannelSendFileEvent(#[from] SendError<crate::file::FileEvent>),
 
+    /// Send error on an Envelope channel.
     #[error("channel: {0}")]
     ChannelSendEnvelope(#[from] SendError<crate::event::Envelope>),
 
+    /// Error returned if the terminfo database is missing.
     #[error("terminfo database not found (is $TERM correct?)")]
     TerminfoDatabaseMissing,
 
+    /// Wrapped error within the context of a command.
     #[error("with command `{command}`: {error}")]
     WithCommand {
+        /// Wrapped error.
         #[source] error: Box<Self>,
+
+        /// Command the error is about.
         command: String,
     },
 
+    /// Wrapped error within the context of a file.
     #[error("with file {file}: {error}")]
     WithFile {
+        /// Wrapped error.
         #[source] error: Box<Self>,
+
+        /// File the error is about.
         file: String,
     },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,78 @@
+//! Error types.
+use std::{
+    ffi::OsStr,
+    result::Result as StdResult,
+    sync::mpsc::{RecvError,  SendError, TryRecvError},
+};
+use thiserror::Error;
+
+/// Convenient return type for functions.
+pub type Result<T> = StdResult<T, Error>;
+
+/// Main error type
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("termwiz: {0}")]
+    Termwiz(anyhow::Error),
+
+    #[error("regex: {0}")]
+    Regex(#[from] regex::Error),
+
+    #[error("i/o: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("temporary file persistence: {0}")]
+    TempfilePersist(#[from] tempfile::PersistError),
+
+    #[error("keymap: {0}")]
+    Keymap(#[from] crate::keymaps::error::KeymapError),
+
+    #[error("binding: {0}")]
+    Binding(#[from] crate::bindings::BindingError),
+
+    #[error("formatting: {0}")]
+    Fmt(#[from] std::fmt::Error),
+
+    #[error("channel: {0}")]
+    ChannelRecv(#[from] RecvError),
+
+    #[error("channel: {0}")]
+    ChannelTryRecv(#[from] TryRecvError),
+
+    #[error("channel: {0}")]
+    ChannelSendFileEvent(#[from] SendError<crate::file::FileEvent>),
+
+    #[error("channel: {0}")]
+    ChannelSendEnvelope(#[from] SendError<crate::event::Envelope>),
+
+    #[error("terminfo database not found (is $TERM correct?)")]
+    TerminfoDatabaseMissing,
+
+    #[error("with command `{command}`: {error}")]
+    WithCommand {
+        #[source] error: Box<Self>,
+        command: String,
+    },
+
+    #[error("with file {file}: {error}")]
+    WithFile {
+        #[source] error: Box<Self>,
+        file: String,
+    },
+}
+
+impl Error {
+    pub(crate) fn with_file(self, file: impl AsRef<str>) -> Self {
+        Self::WithFile {
+            error: Box::new(self),
+            file: file.as_ref().to_owned(),
+        }
+    }
+
+    pub(crate) fn with_command(self, command: impl AsRef<OsStr>) -> Self {
+        Self::WithCommand {
+            error: Box::new(self),
+            command: command.as_ref().to_string_lossy().to_string(),
+        }
+    }
+}

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,11 +1,11 @@
 //! Help screen
 use std::fmt::Write;
 
-use anyhow::Result;
 use termwiz::input::{KeyCode, Modifiers};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::bindings::{Category, Keymap};
+use crate::error::Result;
 
 fn write_key_names(text: &mut String, keys: &[(Modifiers, KeyCode)]) -> Result<usize> {
     let mut w = 0;

--- a/src/keymaps/error.rs
+++ b/src/keymaps/error.rs
@@ -1,29 +1,40 @@
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
+/// Errors specific to keymaps.
 #[derive(Debug, Error)]
 pub enum KeymapError {
+    /// Error when encountering an unknown modifier.
     #[error("unknown modifier: {0}")]
     UnknownModifier(String),
 
+    /// Error when a key definition is missing.
     #[error("key definition missing")]
     MissingDefinition,
 
+    /// Error when a keymap is missing.
     #[error("keymap not found: {0}")]
     MissingKeymap(String),
 
+    /// Error when a key is unrecognised.
     #[error("unrecognised key: {0}")]
     UnknownKey(String),
 
+    /// Parsing error.
     #[error("parse: {0}")]
     Parse(#[from] pest::error::Error<crate::keymap_file::Rule>),
 
+    /// Error related to parsing a binding within a keymap.
     #[error("binding: {0}")]
     Binding(#[from] crate::bindings::BindingError),
 
+    /// Wrapped error within the context of a file.
     #[error("with file {file}: {error}")]
     WithFile {
+        /// Wrapped error.
         #[source] error: Box<KeymapError>,
+
+        /// File the error is about.
         file: PathBuf,
     }
 }

--- a/src/keymaps/error.rs
+++ b/src/keymaps/error.rs
@@ -1,0 +1,40 @@
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum KeymapError {
+    #[error("unknown modifier: {0}")]
+    UnknownModifier(String),
+
+    #[error("key definition missing")]
+    MissingDefinition,
+
+    #[error("keymap not found: {0}")]
+    MissingKeymap(String),
+
+    #[error("unrecognised key: {0}")]
+    UnknownKey(String),
+
+    #[error("parse: {0}")]
+    Parse(#[from] pest::error::Error<crate::keymap_file::Rule>),
+
+    #[error("binding: {0}")]
+    Binding(#[from] crate::bindings::BindingError),
+
+    #[error("with file {file}: {error}")]
+    WithFile {
+        #[source] error: Box<KeymapError>,
+        file: PathBuf,
+    }
+}
+
+impl KeymapError {
+    pub(crate) fn with_file(self, file: impl AsRef<Path>) -> Self {
+        Self::WithFile {
+            error: Box::new(self),
+            file: file.as_ref().to_owned(),
+        }
+    }
+}
+
+pub(crate) type Result<T> = std::result::Result<T, KeymapError>;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -7,11 +7,11 @@
 //! Progress indicator pages are blocks of text terminated by an ASCII form-feed
 //! character.  The progress indicator will display the most recently received
 //! page.
-use anyhow::Result;
 use std::io::{BufRead, BufReader, Read};
 use std::sync::{Arc, RwLock};
 use std::thread;
 
+use crate::error::Result;
 use crate::event::{Event, EventSender, UniqueInstance};
 
 /// Initial buffer size for progress indicator pages.

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,5 +1,4 @@
 //! Prompts for input.
-use anyhow::Error;
 use std::char;
 use std::fmt::Write;
 use termwiz::cell::{AttributeChange, CellAttributes};
@@ -9,6 +8,7 @@ use termwiz::surface::change::Change;
 use termwiz::surface::Position;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
+use crate::error::Error;
 use crate::display::Action;
 use crate::prompt_history::PromptHistory;
 use crate::screen::Screen;

--- a/src/prompt_history.rs
+++ b/src/prompt_history.rs
@@ -1,10 +1,10 @@
 //! Prompt History.
-use anyhow::Error;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use tempfile::NamedTempFile;
 
 use crate::display::Action;
+use crate::error::Error;
 use crate::prompt::PromptState;
 
 const HISTORY_LENGTH: usize = 1000;

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -26,7 +26,6 @@
 //!
 //! ```
 
-use anyhow::Error;
 use std::cmp::{max, min};
 use std::sync::Arc;
 use termwiz::cell::{CellAttributes, Intensity};
@@ -40,6 +39,7 @@ use crate::command;
 use crate::config::{Config, WrappingMode};
 use crate::display::Action;
 use crate::display::Capabilities;
+use crate::error::Error;
 use crate::event::EventSender;
 use crate::file::File;
 use crate::line::Line;

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,4 @@
 //! Searching.
-use anyhow::Error;
 use bit_set::BitSet;
 use lazy_static::lazy_static;
 use regex::bytes::{NoExpand, Regex};
@@ -15,6 +14,7 @@ use termwiz::surface::change::Change;
 use termwiz::surface::Position;
 use unicode_width::UnicodeWidthStr;
 
+use crate::error::Error;
 use crate::event::{Event, EventSender};
 use crate::file::File;
 use crate::overstrike;


### PR DESCRIPTION
As it's a library crate, having Anyhow as its error type makes it harder to integrate with anything that's not using Anyhow itself (chiefly due to it not implementing `std::error::Error`).

This PR refactors the code to use several [thiserror]-derived Error types and completely eliminates anyhow from library code.

It leaves anyhow as the output error library in the sp and spp executables, though.

[thiserror]: https://docs.rs/thiserror

The only holdover is an error variant which wraps anyhow when it comes from termwiz, and I'm also working on refactoring that crate to expose its own error type: https://github.com/wez/wezterm/issues/406