### PR TITLE
Update to termwiz 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,15 +61,6 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -433,12 +424,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,82 +528,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-derive"
-version = "0.2.5"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
- "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -638,9 +555,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "ordered-float"
-version = "1.1.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+checksum = "dacdec97876ef3ede8c50efc429220641a0b11ba0048b4b0c357bccbc47c5204"
 dependencies = [
  "num-traits",
 ]
@@ -672,9 +589,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.56",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -743,29 +660,11 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
- "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -774,7 +673,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -878,7 +777,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -901,18 +800,21 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
 
 [[package]]
 name = "semver-parser"
-version = "0.7.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -929,9 +831,9 @@ version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.56",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -979,15 +881,6 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
@@ -1011,7 +904,7 @@ dependencies = [
  "regex",
  "scopeguard",
  "serde",
- "smallvec 1.5.1",
+ "smallvec",
  "tempfile",
  "terminfo",
  "termwiz",
@@ -1030,24 +923,13 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "unicode-xid 0.2.1",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1098,29 +980,27 @@ dependencies = [
 
 [[package]]
 name = "termwiz"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53116779f1e2e2329a1e34458fdf2c1dd4bca9fbf5aeddafb33d05413091ec35"
+checksum = "5974a7ce9548547add25c7eefd0c1f4ae46290e72a83e57dd7130add746e21bf"
 dependencies = [
  "anyhow",
- "base64 0.10.1",
+ "base64",
  "bitflags",
  "filedescriptor",
  "lazy_static",
  "libc",
  "log",
  "memmem",
- "num",
  "num-derive",
  "num-traits",
  "ordered-float",
  "regex",
  "semver",
- "serde",
  "signal-hook",
- "smallvec 0.6.13",
  "terminfo",
  "termios",
+ "thiserror",
  "unicode-segmentation",
  "unicode-width",
  "vtparse",
@@ -1153,9 +1033,9 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.56",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1202,21 +1082,15 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "utf8parse"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "vec_map"
@@ -1232,9 +1106,9 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "vtparse"
-version = "0.2.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1db1240db68ef2520e7c41dd29651602b3c64d43d639c33fbe4aaf13c9d14c"
+checksum = "d9e4a5b7598a0913469560c36153da5be4729cc8768f8846999f9225104a93c8"
 dependencies = [
  "utf8parse",
 ]
@@ -1311,6 +1185,6 @@ dependencies = [
 
 [[package]]
 name = "xi-unicode"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71b85d8b1b8bfaf4b5c834187554d201a8cd621c2bbfa33efd41a3ecabd48b2"
+checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ pest = { version = "2.1", optional = true }
 pest_derive = { version = "2.1", optional = true }
 regex = "1.1.5"
 scopeguard = "1.0.0"
-serde = "1.0"
+serde = {version="1.0", features=["derive"]}
 smallvec = "1.1.0"
 tempfile = "3.1.0"
 terminfo = "0.7"
-termwiz = "0.8"
+termwiz = "0.11"
 toml = "0.5.6"
 unicode-segmentation = "1.2.1"
 unicode-width = "0.1.5"

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use bit_set::BitSet;
 use termwiz::input::InputEvent;
 use termwiz::surface::change::Change;
-use termwiz::surface::{CursorShape, CursorVisibility, Position};
+use termwiz::surface::{CursorVisibility, Position};
 use termwiz::terminal::Terminal;
 use vec_map::VecMap;
 
@@ -314,7 +314,7 @@ impl StreamingLines {
                 x: Position::Absolute(0),
                 y: Position::Relative(1),
             });
-            changes.push(Change::CursorShape(CursorShape::Default));
+            changes.push(Change::CursorVisibility(CursorVisibility::Visible));
             self.cursor_hidden = false;
         }
         changes

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use bit_set::BitSet;
 use termwiz::input::InputEvent;
 use termwiz::surface::change::Change;
-use termwiz::surface::{CursorShape, Position};
+use termwiz::surface::{CursorShape, CursorVisibility, Position};
 use termwiz::terminal::Terminal;
 use vec_map::VecMap;
 
@@ -289,12 +289,12 @@ impl StreamingLines {
                 y: Position::Relative(0),
             });
             if !self.cursor_hidden {
-                changes.push(Change::CursorShape(CursorShape::Hidden));
+                changes.push(Change::CursorVisibility(CursorVisibility::Hidden));
                 self.cursor_hidden = true;
             }
             progress_row_count -= 1;
         } else if self.cursor_hidden {
-            changes.push(Change::CursorShape(CursorShape::Default));
+            changes.push(Change::CursorVisibility(CursorVisibility::Visible));
             self.cursor_hidden = false;
         }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -10,7 +10,7 @@ use termwiz::cell::CellAttributes;
 use termwiz::color::ColorAttribute;
 use termwiz::input::InputEvent;
 use termwiz::surface::change::Change;
-use termwiz::surface::{CursorShape, Position};
+use termwiz::surface::{CursorVisibility, Position};
 use termwiz::terminal::Terminal;
 use vec_map::VecMap;
 
@@ -209,7 +209,7 @@ pub(crate) fn start(
         let overlay_height = overlay_height.load(Ordering::SeqCst);
         let scroll_count = 1usize.saturating_sub(overlay_height);
         term.render(&[
-            Change::CursorShape(CursorShape::Default),
+            Change::CursorVisibility(CursorVisibility::Visible),
             Change::AllAttributes(CellAttributes::default()),
             Change::ScrollRegionUp {
                 first_row: 0,

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub type Result<T> = StdResult<T, Error>;
 pub enum Error {
     /// Comes from [Termwiz](https://crates.io/crates/termwiz).
     #[error("terminal error")]
-    Termwiz(#[source] anyhow::Error),
+    Termwiz(#[source] termwiz::Error),
 
     /// Comes from [Regex](https://github.com/rust-lang/regex).
     #[error("regex error")]

--- a/src/line.rs
+++ b/src/line.rs
@@ -87,7 +87,7 @@ impl AttributeState {
             match *sgr {
                 Sgr::Reset => {
                     // Reset doesn't clear the hyperlink.
-                    let hyperlink = self.attrs.hyperlink.take();
+                    let hyperlink = self.attrs.hyperlink().cloned();
                     self.attrs = CellAttributes::default();
                     self.attrs.set_hyperlink(hyperlink);
                 }
@@ -119,6 +119,12 @@ impl AttributeState {
                     self.attrs.set_background(color);
                 }
                 Sgr::Font(_) => {}
+                Sgr::UnderlineColor(color) => {
+                    self.attrs.set_underline_color(color);
+                }
+                Sgr::Overline(enable) => {
+                    self.attrs.set_overline(enable);
+                }
             }
         }
         self.changed = true;

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -33,7 +33,7 @@ use termwiz::cell::{CellAttributes, Intensity};
 use termwiz::color::{AnsiColor, ColorAttribute};
 use termwiz::input::KeyEvent;
 use termwiz::surface::change::Change;
-use termwiz::surface::{CursorShape, Position};
+use termwiz::surface::{CursorShape, CursorVisibility, Position};
 
 use crate::bindings::{Binding, Keymap};
 use crate::command;
@@ -259,7 +259,7 @@ impl Screen {
         let mut changes = Vec::new();
 
         // Hide the cursor while we render things.
-        changes.push(Change::CursorShape(CursorShape::Hidden));
+        changes.push(Change::CursorVisibility(CursorVisibility::Hidden));
 
         // Set up the render state.
         let mut render: RenderState = RenderState::default();

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -33,7 +33,7 @@ use termwiz::cell::{CellAttributes, Intensity};
 use termwiz::color::{AnsiColor, ColorAttribute};
 use termwiz::input::KeyEvent;
 use termwiz::surface::change::Change;
-use termwiz::surface::{CursorShape, CursorVisibility, Position};
+use termwiz::surface::{CursorVisibility, Position};
 
 use crate::bindings::{Binding, Keymap};
 use crate::command;
@@ -747,7 +747,7 @@ impl Screen {
                         .expect("prompt row should have been calculated"),
                 ),
             });
-            changes.push(Change::CursorShape(CursorShape::Default));
+            changes.push(Change::CursorVisibility(CursorVisibility::Visible));
         } else {
             changes.push(Change::CursorPosition {
                 x: Position::Absolute(0),


### PR DESCRIPTION
A fairly mechanical change, but note that I had to change the `serde`
features in master to enable `derive` in order for `src/config.rs`
to build.