### PR TITLE
Fix Alt+V keybind

### DIFF
--- a/src/keymaps/default.rs
+++ b/src/keymaps/default.rs
@@ -11,7 +11,7 @@ keymap! {
     SHIFT DownArrow, (ApplicationDownArrow) => ScrollDownScreenFraction(4);
     CTRL UpArrow, 'u', CTRL 'U' => ScrollUpScreenFraction(2);
     CTRL DownArrow, 'd', CTRL 'D' => ScrollDownScreenFraction(2);
-    PageUp, Backspace, 'b', CTRL 'B', ALT 'V' => ScrollUpScreenFraction(1);
+    PageUp, Backspace, 'b', CTRL 'B', ALT 'v' => ScrollUpScreenFraction(1);
     PageDown, ' ', 'f', CTRL 'F', CTRL 'V' => ScrollDownScreenFraction(1);
     Home, 'g', '<' => ScrollToTop;
     End, 'F', 'G', '>' => ScrollToBottom;


### PR DESCRIPTION
Unlike Ctrl, Alt + x needs to use lowercase.